### PR TITLE
support for django >= 1.6

### DIFF
--- a/facebook_connect/urls.py
+++ b/facebook_connect/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 urlpatterns = patterns('',
         url(r'^channel\.html$', 'facebook_connect.views.channel_url', name='channel_url'),


### PR DESCRIPTION
from django.conf.urls.defaults has been removed in Django 1.6 
https://docs.djangoproject.com/en/1.6/internals/deprecation/#id1
